### PR TITLE
Remove blue underline on standards image links in footer

### DIFF
--- a/public/css/leaderboard.css
+++ b/public/css/leaderboard.css
@@ -212,6 +212,10 @@ td {
   width: 90%;
 }
 
+.no-underline {
+  text-decoration:none;
+}
+
 .right {
   padding: 0 2px;
   text-align:right;

--- a/template/footer.php
+++ b/template/footer.php
@@ -10,12 +10,12 @@
     <td style="width:5%">
     </td>
     <td>
-      <a href="http://validator.w3.org/check/referer">
+      <a href="http://validator.w3.org/check/referer" class="no-underline">
         <img src="../public/img/HTML5.png" alt="HTML 5"
             style="border:0;width:24px">
       </a>
 
-      <a href="http://jigsaw.w3.org/css-validator/check/referer">
+      <a href="http://jigsaw.w3.org/css-validator/check/referer" class="no-underline">
         <img style="border:0;width:66px;height:24px"
          src="http://jigsaw.w3.org/css-validator/images/vcss-blue" alt="Valid CSS!">
       </a>


### PR DESCRIPTION
Quick class addition that is applied to links to remove the automatic link underlining. I have applied the class to the two image links to the HTML and CSS standards checkers that you have in the footer. this removes that small bit of blue underlining that shows between the two images.
